### PR TITLE
layout-parser: Fixing 'type' object is not subscriptable error

### DIFF
--- a/server/modules/main/models.py
+++ b/server/modules/main/models.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import List, Optional
+from typing import List, Tuple, Optional
 
 from pydantic import BaseModel, Field
 
@@ -26,7 +26,7 @@ class BoundingBox(BaseModel):
 	)
 
 	@classmethod
-	def from_xyxy(cls, coords: tuple[int, int, int, int]) -> 'BoundingBox':
+	def from_xyxy(cls, coords: Tuple[int, int, int, int]) -> 'BoundingBox':
 		return cls(
 			x=coords[0],
 			y=coords[1],
@@ -43,7 +43,7 @@ class Region(BaseModel):
 		description='Stores the sequential line number of the para text starting from 1'
 	)
 
-	def to_xyxy(self) -> tuple[int, int, int, int]:
+	def to_xyxy(self) -> Tuple[int, int, int, int]:
 		return (
 			self.bounding_box.x,
 			self.bounding_box.y,
@@ -52,7 +52,7 @@ class Region(BaseModel):
 		)
 
 	@classmethod
-	def from_xyxy(cls, coords: tuple[int, int, int, int], label='', line=0):
+	def from_xyxy(cls, coords: Tuple[int, int, int, int], label='', line=0):
 		return cls.from_bounding_box(
 			bbox=BoundingBox.from_xyxy(coords),
 			label=label,


### PR DESCRIPTION
Fixing the below error due to incorrect object type usage

server/modules/main/models.py", line 30, in BoundingBox
    def from_xyxy(cls, coords: tuple[int, int, int, int]) -> 'BoundingBox':
TypeError: 'type' object is not subscriptable

Fixes: 8c922f4115fcb ("added option for dilation of words")